### PR TITLE
Darken link colours to increase contrast for a11y

### DIFF
--- a/src/mailgo.scss
+++ b/src/mailgo.scss
@@ -4,11 +4,11 @@ $mailgo-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
 
 // colors
 $default-color: #4a4a4a;
-$gmail-color: #d44638;
-$outlook-color: #0072c6;
-$wa-color: #00bfa5;
-$telegram-color: #0088cc;
-$skype-color: #00aff0;
+$gmail-color: #c0372a;
+$outlook-color: 0967aa;
+$wa-color: #067466;
+$telegram-color: #086da0;
+$skype-color: #076d92;
 
 $default-color-hover: #3d3d3d;
 


### PR DESCRIPTION
I've darkened the link colours just enough to make them pass WCAG AA contrast. Instead of creating a separate theme for accessible colours, I've overridden the default colours. I see someone has already increased the font size, so I haven't touched anything else.