### PR TITLE
Fixed unit tests errors occurring after update to Jest 27

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     "\\.(sass|scss)$": "<rootDir>/__mocks__/styleMock.js",
   },
   preset: "ts-jest",
+  testEnvironment: "jsdom",
   testMatch: ["**/__tests__/**/*.test.ts"],
   testURL: "http://localhost/",
   verbose: true,


### PR DESCRIPTION
Resolves #107 

After the latest dependencies update the unit tests started to fail.
The issue was related to the update of Jest to version 27. In this new version of Jest the default test environment has been changed from "jsdom" to "node". See this https://jestjs.io/blog/2021/05/25/jest-27#flipping-defaults .
We were affected by this change because we use the DOM APIs and did not have the test environment explicitly configured. So I have configured "testEnvironment": "jsdom" in the jest.config.js file.